### PR TITLE
corretly voting based on verifiers

### DIFF
--- a/voting/majority.py
+++ b/voting/majority.py
@@ -8,10 +8,11 @@ from functools import reduce
 class MajorityVoter:
     def voteOnResult (self,track,res,verifiers=[]):
         name,instances = track.name,track.instances
+        print(res.keys())
         for i,inst in enumerate(instances):
             if inst.expected == None:
-                toolResults = [r[i] for r in res.values ()]
-
+                toolResults = [res[solver][i] for solver in res.keys() if (solver in verifiers or len(verifiers) == 0)]
+                print(toolResults)
                 
                 satVerified = False
                 if len(verifiers) > 0:
@@ -19,7 +20,7 @@ class MajorityVoter:
                     if len(verifiedResults) > 0:
                         satVerified = reduce((lambda x, y: x or y), verifiedResults)
 
-                tts = [r for r in toolResults if r.result == True and r.verified != False]
+                tts = [r for r in toolResults if r.result == True]
                 ffs = [r for r in toolResults if r.result == False]
                 unk = [r for r in toolResults if r.result == None]
                 ctts = len(tts)

--- a/voting/majority.py
+++ b/voting/majority.py
@@ -8,11 +8,9 @@ from functools import reduce
 class MajorityVoter:
     def voteOnResult (self,track,res,verifiers=[]):
         name,instances = track.name,track.instances
-        print(res.keys())
         for i,inst in enumerate(instances):
             if inst.expected == None:
                 toolResults = [res[solver][i] for solver in res.keys() if (solver in verifiers or len(verifiers) == 0)]
-                print(toolResults)
                 
                 satVerified = False
                 if len(verifiers) > 0:


### PR DESCRIPTION
When I try to use zaligvinder to verify the correctness of my tool, Zaligvinder will do a majority vote between all results of the solvers rather than the results of verifiers. So I hack the file voting/majority.py. @qtja 